### PR TITLE
Changed View.propTypes to ViewPropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import {
   StyleSheet,
   Text,
   View,
+  ViewPropTypes,
 } from 'react-native';
 
 const SwipeoutBtn = createReactClass({
@@ -103,7 +104,7 @@ const Swipeout = createReactClass({
     onClose: PropTypes.func,
     right: PropTypes.array,
     scroll: PropTypes.func,
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     sensitivity: PropTypes.number,
     buttonWidth: PropTypes.number,
     disabled: PropTypes.bool,


### PR DESCRIPTION
- In order to prevent Unhandled JS Exception: undefined is not an object (evaluating 'b.View.propTypes.style') on react-native 0.49.*